### PR TITLE
remove auto-run from util.js

### DIFF
--- a/util.js
+++ b/util.js
@@ -86,13 +86,3 @@ exports.readFile = function (parse) {
     })
   })
 }
-
-if(!module.parent) {
-  pull(
-    pull.values(['.']),
-    starStar(),
-    pull.drain(console.log)
-  )
-}
-
-


### PR DESCRIPTION
I'm seeing this code run when bundling with `esbuild`.
Seems like this was vestigal code for testing locally?